### PR TITLE
Added Latest Event Pokemons

### DIFF
--- a/data/event.json
+++ b/data/event.json
@@ -13,5 +13,9 @@
     "Mushroom Nacli",
     "Pumpkaboo Spice Latte",
     "Autumn Dachsbun",
-    "Pile of Leaves Swalot"
+    "Pile of Leaves Swalot",
+    "Overgrown Shiinotic",
+    "Evil Mightyena",
+    "Pumpkin Gothorita",
+    "Voodoo Spinda"
 ]


### PR DESCRIPTION
Added the Halloween 2023 pokemons,

- Evil Mightyena
- Voodoo Spinda
- Pumpkin Gothorita
- Overgrown Shiinotic