### PR TITLE
Fix broken pattern for pokemon with dots in their name

### DIFF
--- a/functions/solveHint.js
+++ b/functions/solveHint.js
@@ -33,7 +33,8 @@ function solveHint(message) {
 
   // Convert the hint to a regex-like pattern
   const hintPattern = pokemonHint
-    .replace(/[!\\\.]/g, "")  // Remove specific characters
+    .replace(/\.([^.]*)$/, "$1")  // Remove trailing dot
+    .replace(/[!\\]/g, "")  // Remove specific characters
     .replace(/_/g, ".");      // Replace underscore with a dot
 
   /**


### PR DESCRIPTION
Current version is broken when trying to solveHint on "The pokémon is \_\_. Rim\_."