### PR TITLE
add default image (substitute doll for now?)

### DIFF
--- a/functions/getImage.js
+++ b/functions/getImage.js
@@ -3,6 +3,7 @@ const images = require("../data/images/images.json");
 const forms = require("../data/images/forms.json");
 const events = require("../data/images/events.json");
 const gigantamaxImages = require("../data/images/gigantamax.json");
+const defaultImg = "https://archives.bulbagarden.net/media/upload/a/a1/Substitute_artwork.png";
 
 /**
  * Retrieves the image URL for a given Pokémon.
@@ -34,7 +35,7 @@ function getImage(pokemon, shiny = false, gigantamax = false) {
     console.log(
       `[PokeHint] Unable to find an image for the Pokémon: ${pokemon}`
     );
-    return null;
+    return defaultImg;
   }
 
   // Replace 'images' with 'shiny' in the URL if shiny version is requested

--- a/functions/getImage.js
+++ b/functions/getImage.js
@@ -3,7 +3,6 @@ const images = require("../data/images/images.json");
 const forms = require("../data/images/forms.json");
 const events = require("../data/images/events.json");
 const gigantamaxImages = require("../data/images/gigantamax.json");
-const defaultImg = "https://archives.bulbagarden.net/media/upload/a/a1/Substitute_artwork.png";
 
 /**
  * Retrieves the image URL for a given Pokémon.
@@ -35,7 +34,7 @@ function getImage(pokemon, shiny = false, gigantamax = false) {
     console.log(
       `[PokeHint] Unable to find an image for the Pokémon: ${pokemon}`
     );
-    return defaultImg;
+    return "https://res.cloudinary.com/dppthk8lt/image/upload/v1749666743/question_mkani5.png";
   }
 
   // Replace 'images' with 'shiny' in the URL if shiny version is requested


### PR DESCRIPTION
logs show a substitute doll if no image is available, letting it display other details instead of returning an error

previously it just skips if there's no image